### PR TITLE
refactor(docs): minimize the use of abbreviations

### DIFF
--- a/docs/martin-fowler/dispensables/lazy-class/index.md
+++ b/docs/martin-fowler/dispensables/lazy-class/index.md
@@ -4,7 +4,7 @@
 
 ## Penjelasan Smell
 
-Memecah class memang bagus, terlebih bila bertujuan untuk memenuhi SRP. Class yang terlalu gemuk juga sudah dibahas di code smell Large Class.
+Memecah class memang bagus, terlebih bila bertujuan untuk memenuhi Single Responsibility Principle (SRP). Class yang terlalu gemuk juga sudah dibahas di code smell Large Class.
 
 Namun, class yang terlalu kecil juga tidak baik karena semakin banyak class yang harus dibaca, semakin sulit programmer memahami code suatu produk.
 


### PR DESCRIPTION
Penggunaan kata singkatan dapat diminimalisir untuk membuat user semakin paham dari isi konten, singkatan baiknya digunakan sebelum penjelasan terkait singkatan tersebut, disini saya mencoba membuat pembaca memahami bahwa yang dimaksud adalah Single Responsibility Principle.